### PR TITLE
feat(ui): create product card component with shadcn/ui

### DIFF
--- a/components/shared/product/productCard.tsx
+++ b/components/shared/product/productCard.tsx
@@ -1,0 +1,44 @@
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import React from "react";
+import Link from "next/link";
+import Image from "next/image";
+
+interface ProductCardProps {
+  product: any;
+}
+
+const ProductCard: React.FC<ProductCardProps> = ({ product }) => {
+  const productLink = `/products/${product.slug}`;
+
+  return (
+    <Card className="w-full max-w-sm">
+      <CardHeader className="p-0 items-center">
+        <Link href={productLink}>
+          <Image
+            src={product.images[0]}
+            alt={product.name}
+            width={300}
+            height={300}
+            priority={true}
+          />
+        </Link>
+      </CardHeader>
+      <CardContent className="p-4 grid gap-4">
+        <div className="text-xs">{product.brand}</div>
+        <Link href={productLink}>
+          <h2 className="text-sm font-medium">{product.name}</h2>
+        </Link>
+        <div className="flex-between gap-4">
+          <p>{product.rating} Stars</p>
+          {product.stock > 0 ? (
+            <p className="font-bold">${product.price}</p>
+          ) : (
+            <p className="text-destructive">Out Of Stock</p>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default ProductCard;

--- a/components/shared/product/productList.tsx
+++ b/components/shared/product/productList.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import ProductCard from "./productCard";
 
 interface ProductListProps {
   data: any;
@@ -15,7 +16,7 @@ const ProductList: React.FC<ProductListProps> = ({ data, title, limit }) => {
       {data.length > 0 ? (
         <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
           {limitedData.map((product: any) => (
-            <div key={product.slug}>{product.name}</div>
+            <ProductCard key={product.slug} product={product} />
           ))}
         </div>
       ) : (

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,0 +1,79 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-lg border bg-card text-card-foreground shadow-sm",
+      className
+    )}
+    {...props}
+  />
+))
+Card.displayName = "Card"
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+))
+CardHeader.displayName = "CardHeader"
+
+const CardTitle = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "text-2xl font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+CardTitle.displayName = "CardTitle"
+
+const CardDescription = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+CardDescription.displayName = "CardDescription"
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+))
+CardContent.displayName = "CardContent"
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+))
+CardFooter.displayName = "CardFooter"
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }


### PR DESCRIPTION
Created a reusable ProductCard component using shadcn/ui. Displays product image, title, price, and optional actions. Designed for use in product lists and grids.