### PR TITLE
feat(db): fetch latest products using server actions

### DIFF
--- a/app/(root)/page.tsx
+++ b/app/(root)/page.tsx
@@ -1,8 +1,12 @@
 import ProductList from "@/components/shared/product/productList";
-import sampleData from "@/db/sample-data";
+import { ProductActions } from "@/lib/actions/product.actions";
 
 const Homepage = async () => {
-  return <ProductList data={sampleData.products} title="Newst Arrivals" limit={4} />;
+  const lastestProducts = await ProductActions.getLatestProducts();
+
+  return (
+    <ProductList data={lastestProducts} title="Newst Arrivals" />
+  );
 };
 
 export default Homepage;

--- a/lib/actions/product.actions.ts
+++ b/lib/actions/product.actions.ts
@@ -1,0 +1,20 @@
+'use server';
+import { PrismaClient } from "@/lib/generated/prisma";
+import { convertToPlainObject } from "@/lib/utils"
+import { LATEST_PRODUCTS_LIMIT } from "@/lib/constants/index"
+
+
+export const ProductActions = {
+    getLatestProducts: async (limit = LATEST_PRODUCTS_LIMIT) => {
+        const prisma = new PrismaClient();
+
+        const data = await prisma.product.findMany({
+            take: limit,
+            orderBy: {
+                createdAt: 'desc'
+            }
+        })
+
+        return convertToPlainObject(data);
+    }
+}

--- a/lib/constants/index.ts
+++ b/lib/constants/index.ts
@@ -1,3 +1,4 @@
 export const APP_NAME = process.env.NEXT_PUBLIC_APP_NAME || "DevwkStore";
 export const APP_DESCRIPTION = process.env.NEXT_PUBLIC_APP_DESCRIPTION || "A modern ecommerce platform built with Next.js";
-export const SERVER_URL = process.env.NEXT_PUBLIC_SERVER_URL || "http://localhost:3000"
+export const SERVER_URL = process.env.NEXT_PUBLIC_SERVER_URL || "http://localhost:3000";
+export const LATEST_PRODUCTS_LIMIT = Number(process.env.LATEST_PRODUCTS_LIMIT) || 4;

--- a/lib/generated/prisma/edge.js
+++ b/lib/generated/prisma/edge.js
@@ -167,11 +167,12 @@ const config = {
     "db"
   ],
   "activeProvider": "postgresql",
+  "postinstall": false,
   "inlineDatasources": {
     "db": {
       "url": {
         "fromEnvVar": "DATABASE_URL",
-        "value": "postgres://neondb_owner:npg_8wAVFGxM2vfH@ep-proud-truth-ac9tpomk-pooler.sa-east-1.aws.neon.tech/neondb?sslmode=require"
+        "value": null
       }
     }
   },

--- a/lib/generated/prisma/index.js
+++ b/lib/generated/prisma/index.js
@@ -168,11 +168,12 @@ const config = {
     "db"
   ],
   "activeProvider": "postgresql",
+  "postinstall": false,
   "inlineDatasources": {
     "db": {
       "url": {
         "fromEnvVar": "DATABASE_URL",
-        "value": "postgres://neondb_owner:npg_8wAVFGxM2vfH@ep-proud-truth-ac9tpomk-pooler.sa-east-1.aws.neon.tech/neondb?sslmode=require"
+        "value": null
       }
     }
   },

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,8 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+// Convert prisma object into a regular JS object
+export function convertToPlainObject<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value))
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "devwkstore",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.11",
         "@radix-ui/react-dropdown-menu": "^2.1.12",


### PR DESCRIPTION
Created a getLatestProducts server action to fetch data from the database using Prisma. Updated the Home page to use this action instead of hardcoded sample data. Added a utility to convert Prisma responses into plain JS objects to avoid serialization issues. Introduced a configurable limit for latest products.