### PR TITLE
feat(auth): add sign in and sign out server actions

### DIFF
--- a/lib/actions/user.actions.ts
+++ b/lib/actions/user.actions.ts
@@ -1,0 +1,34 @@
+'use server';
+
+import { signInFormSchema } from "../validators/form";
+import { signIn, signOut } from "@/auth"
+import { isRedirectError } from "next/dist/client/components/redirect";
+
+export async function signInWithCredentials(prevState: unknown, formaData: FormData) {
+    try {
+        const user = signInFormSchema.parse({
+            email: formaData.get('email'),
+            password: formaData.get('password'),
+        })
+
+        await signIn('credentials', user);
+
+
+
+        return {
+            success: true, message: 'Signed in successfully'
+        }
+    } catch (error) {
+        if (isRedirectError(error)) {
+            throw error;
+        }
+
+        return {
+            success: false, message: 'Invalid email or password'
+        }
+    }
+}
+
+export async function signOutUser() {
+    await signOut()
+}

--- a/lib/validators/form.ts
+++ b/lib/validators/form.ts
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const signInFormSchema = z.object({
+    email: z.string().email('Invalid email address'),
+    password: z.string().min(6, 'Password must be at least 6 characters')
+})


### PR DESCRIPTION
Implemented signInAction and signOutAction using NextAuth's signIn and signOut helpers. These actions can now be triggered from the UI to manage user authentication without relying on client-side routing.