### PR TITLE
feat(auth): customize JWT token using callback for user session data

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -68,7 +68,24 @@ export const config = {
 
             return session;
         },
+        async jwt({ token, user, trigger, session }: any) {
+            // Assign user fields to token
+            if (user) {
+                token.role = user.role
 
+                // If user has no name then usse the email
+                if (user.name === "NO_NAME") {
+                    token.name = user.email!.split("@")[0]
+
+                    // Update database to reflect the token name
+                    await prisma.user.update({
+                        where: { id: user.id },
+                        data: { name: token.name }
+                    })
+                }
+            }
+            return token;
+        }
     },
 } satisfies NextAuthConfig;
 


### PR DESCRIPTION
Extended the NextAuth JWT callback to include custom user data in the token. Now the session includes the user's ID and name for improved access control and personalization.